### PR TITLE
add apt-get upgrade execute resource

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,6 +32,13 @@ execute "apt-get update" do
   action :nothing
 end
 
+# For other recipes to trigger an apt-get update && apt-get upgrade
+execute "apt-get upgrade" do
+  command "apt-get update && apt-get upgrade -y"
+  ignore_failure true
+  action :nothing
+end
+
 # provides /var/lib/apt/periodic/update-success-stamp on apt-get update
 package "update-notifier-common" do
   notifies :run, resources(:execute => "apt-get-update"), :immediately


### PR DESCRIPTION
I added an apt-get upgrade execute resource that can be manually run from other recipes. Here's my use case:

On Linode, when I bootstrap a new Ubuntu 11.10 node with knife linode server create, I need the latest packages installed or my private IP address won't show up correctly and my other recipes that need that will fail.

So I use this to run an apt-get update && apt-get upgrade -y on the first boot only (i.e. not on every chef-client run).
