### PR TITLE
[COOK-1229] Allow cacher IP to be set manually in non-Chef Solo environments

### DIFF
--- a/recipes/cacher-client.rb
+++ b/recipes/cacher-client.rb
@@ -25,16 +25,14 @@ execute "Remove proxy from /etc/apt/apt.conf" do
 end
 
 servers = []
-if Chef::Config['solo']
-  if node['apt'] && node['apt']['cacher_ipaddress']
-    cacher = Chef::Node.new
-    cacher.name(node['apt']['cacher_ipaddress'])
-    cacher.ipaddress(node['apt']['cacher_ipaddress'])
-    servers << cacher
-  end
-else
-  servers += search(:node, 'recipes:apt\:\:cacher-ng')
+if node['apt'] && node['apt']['cacher_ipaddress']
+  cacher = Chef::Node.new
+  cacher.name(node['apt']['cacher_ipaddress'])
+  cacher.ipaddress(node['apt']['cacher_ipaddress'])
+  servers << cacher
 end
+
+servers += search(:node, 'recipes:apt\:\:cacher-ng') unless Chef::Config[:solo]
 
 if servers.length > 0
   Chef::Log.info("apt-cacher-ng server found on #{servers[0]}.")


### PR DESCRIPTION
If you aren't running Chef Solo, there is no way to explicitly set `cacher_ipaddress`. I think explicit `cacher_ipaddress` attribute overrides should work in non-Chef Solo environments.
