### PR TITLE
[COOK-1382] Trigger APT update immediately after adding a new repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Adding a new repository will notify running the
 - cookbook: if key should be a cookbook_file, specify a cookbook where
   the key is located for files/default. Defaults to nil, so it will
   use the cookbook where the resource is used.
+- immediate_cache_rebuild: if the APT cache should be updated after repository
+  addition - value can be `true` or `false`, default `true`.
 
 # Examples
 
@@ -108,6 +110,15 @@ Adding a new repository will notify running the
       distribution node['lsb']['codename']
       components ["main"]
       key "cloudkick.packages.key"
+    end
+
+    # add the Cloudkick Repo and don't trigger an APT cache update immediately
+    apt_repository "cloudkick" do
+      uri "http://packages.cloudkick.com/ubuntu"
+      distribution node['lsb']['codename']
+      components ["main"]
+      key "http://packages.cloudkick.com/cloudkick.packages.key"
+      immediate_cache_rebuild false
     end
 
     # remove Zenoss repo

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -92,7 +92,7 @@ action :add do
       mode 0644
       content repository
       action :create
-      notifies :run, resources(:execute => "apt-get update"), :immediately
+      notifies :run, resources(:execute => "apt-get update"), (new_resource.immediate_cache_rebuild ? :immediately : :delayed)
     end
 end
 

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -34,3 +34,4 @@ attribute :deb_src, :default => false
 attribute :keyserver, :kind_of => String, :default => nil
 attribute :key, :kind_of => String, :default => nil
 attribute :cookbook, :kind_of => String, :default => nil
+attribute :immediate_cache_rebuild, :default => true


### PR DESCRIPTION
The scenario I'm running into:
1. Add a new repository with a more up-to-date package that is already in the base repositories (ex: duplicity ppa)
2. Attempt to install package, but older version installs because `apt-get update` is delayed to the end of the Chef run

Setting the post-installation `apt-get update` to `:immediately` should make it so that the new version is available for installation right away.  Unfortunately, if you are adding multiple repositories, you'll pay the cache rebuilding costs each time.  To get around this, I added a `immediate_cache_rebuild` attribute to the `repository` resource.  Setting it to `true` (the default) makes the `apt-get update` notification to `:immediately` -- setting it to `false` leaves the notification timing as `:delayed`.
