### PR TITLE
Use ".pref" as file extension for preferences.d files

### DIFF
--- a/providers/preference.rb
+++ b/providers/preference.rb
@@ -29,7 +29,7 @@ action :add do
                           new_resource.pin,
                           new_resource.pin_priority)
 
-  preference_file = file "/etc/apt/preferences.d/#{new_resource.package_name}" do
+  preference_file = file "/etc/apt/preferences.d/#{new_resource.package_name}.pref" do
     owner "root"
     group "root"
     mode 0644
@@ -42,9 +42,9 @@ action :add do
 end
 
 action :remove do
-  if ::File.exists?("/etc/apt/preferences.d/#{new_resource.package_name}")
+  if ::File.exists?("/etc/apt/preferences.d/#{new_resource.package_name}.pref")
     Chef::Log.info "Un-pinning #{new_resource.package_name} from /etc/apt/preferences.d/"
-    file "/etc/apt/preferences.d/#{new_resource.package_name}" do
+    file "/etc/apt/preferences.d/#{new_resource.package_name}.pref" do
       action :delete
     end
     new_resource.updated_by_last_action(true)


### PR DESCRIPTION
Packages with periods in the name will cause apt to think that everything to the right of the period is a file extension, and this causes apt to ignore those files and generate a notice:

N: Ignoring file 'postgresql-9.1' in directory '/etc/apt/preferences.d/' as it has an invalid filename extension
N: Ignoring file 'postgresql-client-9.1' in directory '/etc/apt/preferences.d/' as it has an invalid filename extension

Per apt_preferences(5) ".pref" is an acceptable extension and solves this issue.
