### PR TITLE
Cook 1500

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -105,7 +105,6 @@ action :add do
                             new_resource.components,
                             new_resource.deb_src)
 
-    notify_type = new_resource.immediate_cache_rebuild ? :immediately : :delayed
     f = file "/etc/apt/sources.list.d/#{new_resource.repo_name}-source.list" do
       owner "root"
       group "root"
@@ -113,7 +112,7 @@ action :add do
       content repository
       action :create
       notifies :delete, resources(:file => "/var/lib/apt/periodic/update-success-stamp"), :immediately
-      notifies :run, resources(:execute => "apt-get update"), notify_type if new_resource.cache_rebuild
+      notifies :run, resources(:execute => "apt-get update"), :immediately if new_resource.cache_rebuild
     end
     new_resource.updated_by_last_action(f.updated?)
 end

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -34,8 +34,6 @@ attribute :deb_src, :default => false
 attribute :keyserver, :kind_of => String, :default => nil
 attribute :key, :kind_of => String, :default => nil
 attribute :cookbook, :kind_of => String, :default => nil
-#trigger cache rebuild controls
+#trigger cache rebuild
 #If not you can trigger in the recipe itself after checking the status of resource.updated{_by_last_action}?
 attribute :cache_rebuild, :kind_of => [TrueClass, FalseClass], :default => true
-#immediate or delayed, makes sense if cache_rebuild == true
-attribute :immediate_cache_rebuild, :kind_of => [TrueClass, FalseClass], :default => true


### PR DESCRIPTION
New request for COOK-1500, seems I messed up the first one.

Avoid triggering apt-get update

This allows:

``` ruby
#run apt-get update after the 2 repos are added. Not each time.
r = apt_repository 'A' do
  uri 'http://A'
  deb_src true
  apt_update false
  action :nothing
end
r.run_action(:add)
updated = r.updated?

r = apt_repository 'B' do
  uri 'http://B'
  apt_update false
  action :nothing
end
r.run_action(:add)
updated ||= r.updated?

if updated
  resources(:execute => 'apt-get update').run_action(:run)
end
```
