### PR TITLE
Proxy for apt-key

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,22 @@
+#
+# Author:: Lukasz Jagiello (<lukasz@wikia-inc.com>)
+# Cookbook Name:: apt
+# Attribute:: default
+#
+# Copyright 2012, Wikia, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Example: default['apt']['proxy'] = 'http://your.proxy:3128'
+default['apt']['proxy'] = ''

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -21,7 +21,11 @@
 def install_key_from_keyserver(key, keyserver)
   unless system("apt-key list | grep #{key}")
     execute "install-key #{key}" do
-      command "apt-key adv --keyserver #{keyserver} --recv #{key}"
+      if !node['apt']['proxy'].empty?
+        command "apt-key adv --keyserver-options http-proxy=#{node['apt']['proxy']} --keyserver #{keyserver} --recv #{key}"
+      else
+        command "apt-key adv --keyserver #{keyserver} --recv #{key}"
+      end
       action :nothing
     end.run_action(:run)
     new_resource.updated_by_last_action(true)


### PR DESCRIPTION
Apt proxy configuration doesn't work for apt-key.

Here is my solution with "--keyserver-options" and set http-proxy over attribute.
