### PR TITLE
Additional parameter in preferences LWRP provider

### DIFF
--- a/providers/preference.rb
+++ b/providers/preference.rb
@@ -22,14 +22,19 @@ def build_pref(package_name, pin, pin_priority)
   preference_content = "Package: #{package_name}\nPin: #{pin}\nPin-Priority: #{pin_priority}\n"
 end
 
+
 action :add do
+  if not new_resource.package_name
+    new_resource.package_name = new_resource.name 
+  end
+
   new_resource.updated_by_last_action(false)
 
   preference = build_pref(new_resource.package_name,
                           new_resource.pin,
                           new_resource.pin_priority)
 
-  preference_file = file "/etc/apt/preferences.d/#{new_resource.package_name}" do
+  preference_file = file "/etc/apt/preferences.d/#{new_resource.name}" do
     owner "root"
     group "root"
     mode 0644
@@ -42,9 +47,13 @@ action :add do
 end
 
 action :remove do
-  if ::File.exists?("/etc/apt/preferences.d/#{new_resource.package_name}")
+  if not new_resource.package_name
+    new_resource.package_name = new_resource.name 
+  end
+
+  if ::File.exists?("/etc/apt/preferences.d/#{new_resource.name}")
     Chef::Log.info "Un-pinning #{new_resource.package_name} from /etc/apt/preferences.d/"
-    file "/etc/apt/preferences.d/#{new_resource.package_name}" do
+    file "/etc/apt/preferences.d/#{new_resource.name}" do
       action :delete
     end
     new_resource.updated_by_last_action(true)

--- a/resources/preference.rb
+++ b/resources/preference.rb
@@ -24,6 +24,7 @@ def initialize(*args)
   @action = :add
 end
 
-attribute :package_name, :kind_of => String, :name_attribute => true
+attribute :package_name, :kind_of => String
 attribute :pin, :kind_of => String
+attribute :name, :kind_of => String, :name_attribute => true
 attribute :pin_priority, :kind_of => String


### PR DESCRIPTION
Added additional parameter :name into preference resource in order to distinguish preferences file name and package name inside preferences file. It fixes the problem I encountered on Debian Squeeze where file /etc/apt/preferences.d/\* does not work (does not change priority). 
