### PR TITLE
Fixed idempotency problem where keys install over and over

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -62,7 +62,7 @@ def install_key_from_uri(uri)
 
   installed_ids = extract_gpg_ids_from_cmd("apt-key finger")
   key_ids = extract_gpg_ids_from_cmd("gpg --with-fingerprint #{cached_keyfile}")
-  unless installed_ids & key_ids == key_ids
+  unless (installed_ids & key_ids).sort == key_ids.sort
     execute "install-key #{key_name}" do
       command "apt-key add #{cached_keyfile}"
       action :nothing


### PR DESCRIPTION
It's just an implementation bug. The original author used set logic and ended up comparing arrays. The equality operator for arrays takes order into account, but that's not what the original author meant. It's just a bug. By sorting both sides of the equality I turned it into what the original author meant to write.
