### PR TITLE
[COOK-1914] Fix /etc/apt/preferences.d/ permissions

### DIFF
--- a/providers/preference.rb
+++ b/providers/preference.rb
@@ -32,7 +32,7 @@ action :add do
   preference_dir = directory "/etc/apt/preferences.d" do
     owner "root"
     group "root"
-    mode 00644
+    mode 00755
     recursive true
     action :nothing
   end


### PR DESCRIPTION
This directory was missed by e1ba5f8dce526e458e4c309a70499a47481cf60d.

Ticket: [COOK-1914](http://tickets.opscode.com/browse/COOK-1914)
