### PR TITLE
Documentation fix for COOK-1942

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ resource immediately.
 - components: package groupings..when it doubt use `main`
 - deb_src: whether or not to add the repository as a source repo as
   well - value can be `true` or `false`, default `false`.
-- key_server: the GPG keyserver where the key for the repo should be retrieved
-- key: if a `key_server` is provided, this is assumed to be the
+- keyserver: the GPG keyserver where the key for the repo should be retrieved
+- key: if a `keyserver` is provided, this is assumed to be the
   fingerprint, otherwise it can be either the URI to the GPG key for
   the repo, or a cookbook_file.
 - cookbook: if key should be a cookbook_file, specify a cookbook where


### PR DESCRIPTION
Document correct name of `keyserver` attribute of `apt_repository` LWRP.
