### PR TITLE
Fix cacher_ipaddress doc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Configures the node to use the `apt-cacher-ng` server as a client. If you
 want to restrict your node to using the `apt-cacher-ng` server in your
 Environment, set `['apt']['cacher-client']['restrict_environment']` to `true`.
 To use a cacher server (or standard proxy server) not available via search
-set the atttribute `['apt']['cacher-ipaddress']` and for a custom port
+set the atttribute `['apt']['cacher_ipaddress']` and for a custom port
 set `['apt']['cacher_port']`
 
 Resources/Providers


### PR DESCRIPTION
As per https://github.com/opscode-cookbooks/apt/blob/master/recipes/cacher-client.rb#L28 there should be an underscore in the docs, I used the dash and it took me several minutes to find my error.
