### PR TITLE
[COOK-2185] Proxy for apt-key, apt proxy configuration doesn't work

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default['apt']['cacher-client']['restrict_environment'] = false
 default['apt']['cacher_port'] = 3142
+default['apt']['key_proxy'] = ''

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -24,7 +24,11 @@ end
 # install apt key from keyserver
 def install_key_from_keyserver(key, keyserver)
   execute "install-key #{key}" do
-    command "apt-key adv --keyserver #{keyserver} --recv #{key}"
+    if !node['apt']['key_proxy'].empty?
+      command "apt-key adv --keyserver-options http-proxy=#{node['apt']['key_proxy']} --keyserver #{keyserver} --recv #{key}"
+    else
+      command "apt-key adv --keyserver #{keyserver} --recv #{key}"
+    end
     action :run
     not_if "apt-key list | grep #{key}"
   end


### PR DESCRIPTION
Patch for:
http://tickets.opscode.com/browse/COOK-2185
