### PR TITLE
Fix cacher-client recipe for Chef 11

### DIFF
--- a/recipes/cacher-client.rb
+++ b/recipes/cacher-client.rb
@@ -27,8 +27,8 @@ end
 servers = []
 if node['apt'] && node['apt']['cacher_ipaddress']
   cacher = Chef::Node.new
-  cacher.name(node['apt']['cacher_ipaddress'])
-  cacher.ipaddress(node['apt']['cacher_ipaddress'])
+  cacher.default.name = node['apt']['cacher_ipaddress']
+  cacher.default.ipaddress = node['apt']['cacher_ipaddress']
   servers << cacher
 end
 


### PR DESCRIPTION
The apt-client recipe is using methods no longer valid in Chef 11 to write attributes
