### PR TITLE
Regression for chef 11

### DIFF
--- a/recipes/cacher-client.rb
+++ b/recipes/cacher-client.rb
@@ -28,7 +28,7 @@ servers = []
 if node['apt'] && node['apt']['cacher_ipaddress']
   cacher = Chef::Node.new
   cacher.name(node['apt']['cacher_ipaddress'])
-  cacher.ipaddress(node['apt']['cacher_ipaddress'])
+  cacher.default_attrs={:ipaddress => node['apt']['cacher_ipaddress']}
   servers << cacher
 end
 


### PR DESCRIPTION
Since Chef 11 attributes creation is not allowed anymore via the method_missing funcion. So the new attribute has to be created explicitly.
