### PR TITLE
Modified the keyserver param when using a proxy

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -25,7 +25,7 @@ end
 def install_key_from_keyserver(key, keyserver)
   execute "install-key #{key}" do
     if !node['apt']['key_proxy'].empty?
-      command "apt-key adv --keyserver-options http-proxy=#{node['apt']['key_proxy']} --keyserver #{keyserver} --recv #{key}"
+      command "apt-key adv --keyserver-options http-proxy=#{node['apt']['key_proxy']} --keyserver hkp://#{keyserver}:80 --recv #{key}"
     else
       command "apt-key adv --keyserver #{keyserver} --recv #{key}"
     end


### PR DESCRIPTION
The --keyserver parameter needs to be given with the hkp:// and port 80 for it to work through a proxy server.
