### PR TITLE
Install Mixlib::ShellOut for backwards compatibility with older chef versions

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -34,8 +34,30 @@ def install_key_from_keyserver(key, keyserver)
   end
 end
 
+def install_shellout
+  if defined?(chef_gem) then
+    r = chef_gem 'mixlib-shellout' do
+      action :nothing
+    end
+  else
+    r = gem_package 'mixlib-shellout' do
+      action :nothing
+    end
+  end
+  r.run_action(:install)
+  Gem.clear_paths
+  require 'mixlib/shellout'
+end
+
 # run command and extract gpg ids
 def extract_gpg_ids_from_cmd(cmd)
+  if not defined?(Mixlib::Shellout) then
+    begin
+      require 'mixlib/shellout'
+    rescue LoadError
+      install_shellout
+    end
+  end
   so = Mixlib::ShellOut.new(cmd)
   so.run_command
   so.stdout.split(/\n/).collect do |t|


### PR DESCRIPTION
This provider failed when I ran it using chef 0.10.8 due to missing Mixlib::ShellOut. 

Ticket: http://tickets.opscode.com/browse/COOK-2742
