### PR TITLE
[COOK-2859] prevent forced run of cacher-client recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ want to restrict your node to using the `apt-cacher-ng` server in your
 Environment, set `['apt']['cacher-client']['restrict_environment']` to `true`.
 To use a cacher server (or standard proxy server) not available via search
 set the atttribute `['apt']['cacher-ipaddress']` and for a custom port
-set `['apt']['cacher_port']`
+set `['apt']['cacher_port']`. 
+
+Set `['apt']['compiletime']` to true to force the `cacher-client` recipe to 
+run before other recipes. This can be useful in some cases as it forces apt 
+to use the proxy before other recipes run. Useful if your nodes have limited 
+access to public apt repositories but can prevent the `cacher-ng` recipe from
+completing. Default is false.
 
 Resources/Providers
 ===================

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,4 @@
 default['apt']['cacher-client']['restrict_environment'] = false
 default['apt']['cacher_port'] = 3142
 default['apt']['key_proxy'] = ''
+default['apt']['compiletime'] = false

--- a/recipes/cacher-client.rb
+++ b/recipes/cacher-client.rb
@@ -41,7 +41,7 @@ end
 
 if servers.length > 0
   Chef::Log.info("apt-cacher-ng server found on #{servers[0]}.")
-  template '/etc/apt/apt.conf.d/01proxy' do
+  t = template '/etc/apt/apt.conf.d/01proxy' do
     source '01proxy.erb'
     owner 'root'
     group 'root'
@@ -50,7 +50,9 @@ if servers.length > 0
       :proxy => servers[0]['ipaddress'],
       :port => node['apt']['cacher_port']
       )
-  end.run_action(:create)
+    action( node['apt']['compiletime'] ? :nothing : :create )
+  end
+  t.run_action(:create) if node['apt']['compiletime']
 else
   Chef::Log.info('No apt-cacher-ng server found.')
   file '/etc/apt/apt.conf.d/01proxy' do


### PR DESCRIPTION
Added option for user to force execution of cacher-client recipe at compile time. Previously, this feature was forced by the recipe.
