### PR TITLE
Long GPG key-IDs

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -32,7 +32,7 @@ def install_key_from_keyserver(key, keyserver)
     action :run
     not_if do
         extract_fingerprints_from_cmd("apt-key finger").any? do |fingerprint|
-            fingerprint.end_with?(key)
+            fingerprint.end_with?(key.upcase)
         end
     end
   end


### PR DESCRIPTION
This fixes [COOK-3052](http://tickets.opscode.com/browse/COOK-3052)
And [COOK-1856](http://tickets.opscode.com/browse/COOK-1856) while I was there...

CLA machinery still in motion...

Test run on

```
apt_repository "dell" do
  uri "http://linux.dell.com/repo/community/deb/latest"
  components ["/"]
  keyserver "pool.sks-keyservers.net"
  keyserver "subkeys.pgp.net"
  key "1285491434D8786F"
  action :add
end
```

```
[Mon, 27 May 2013 13:53:05 +0000] INFO: Processing apt_repository[dell] action add (apt::test line 1)
[Mon, 27 May 2013 13:53:05 +0000] WARN: Cloning resource attributes for execute[install-key 1285491434D8786F] from prior resource (CHEF-3694)
[Mon, 27 May 2013 13:53:05 +0000] WARN: From: /home/stefanor/git/yola/Chef/local-cookbooks/apt/providers/repository.rb:26:in `install_key_from_keyserver'
[Mon, 27 May 2013 13:53:05 +0000] WARN: Cloning resource attributes for file[/var/lib/apt/periodic/update-success-stamp] from prior resource (CHEF-3694)
[Mon, 27 May 2013 13:53:05 +0000] WARN: From: /home/stefanor/git/yola/Chef/local-cookbooks/apt/providers/repository.rb:104:in `class_from_file'
[Mon, 27 May 2013 13:53:05 +0000] WARN: Cloning resource attributes for execute[apt-get update] from prior resource (CHEF-3694)
[Mon, 27 May 2013 13:53:05 +0000] WARN: From: /home/stefanor/git/yola/Chef/local-cookbooks/apt/providers/repository.rb:108:in `class_from_file'
[Mon, 27 May 2013 13:53:05 +0000] WARN: Cloning resource attributes for file[/etc/apt/sources.list.d/dell.list] from prior resource (CHEF-3694)
[Mon, 27 May 2013 13:53:05 +0000] WARN: From: /home/stefanor/git/yola/Chef/local-cookbooks/apt/providers/repository.rb:120:in `class_from_file'
[Mon, 27 May 2013 13:53:05 +0000] INFO: Processing execute[install-key 1285491434D8786F] action run (/home/stefanor/git/yola/Chef/local-cookbooks/apt/providers/repository.rb line 26)
[Mon, 27 May 2013 13:53:06 +0000] DEBUG: Skipping execute[install-key 1285491434D8786F] due to not_if ruby block
[Mon, 27 May 2013 13:53:06 +0000] INFO: Processing file[/var/lib/apt/periodic/update-success-stamp] action nothing (/home/stefanor/git/yola/Chef/local-cookbooks/apt/providers/repository.rb line 104)
[Mon, 27 May 2013 13:53:06 +0000] DEBUG: Doing nothing for file[/var/lib/apt/periodic/update-success-stamp]
[Mon, 27 May 2013 13:53:06 +0000] INFO: Processing execute[apt-get update] action nothing (/home/stefanor/git/yola/Chef/local-cookbooks/apt/providers/repository.rb line 108)
[Mon, 27 May 2013 13:53:06 +0000] DEBUG: Doing nothing for execute[apt-get update]
[Mon, 27 May 2013 13:53:06 +0000] INFO: Processing file[/etc/apt/sources.list.d/dell.list] action create (/home/stefanor/git/yola/Chef/local-cookbooks/apt/providers/repository.rb line 120)
```

And with:

```
  key "42550abd1E80D7C1BC0BAD851285491434D8786F"
```

```
[Mon, 27 May 2013 13:55:51 +0000] INFO: Processing execute[install-key 42550abd1E80D7C1BC0BAD851285491434D8786F] action run (/home/stefanor/git/yola/Chef/local-cookbooks/apt/providers/repository.rb line 26)
[Mon, 27 May 2013 13:55:51 +0000] DEBUG: Skipping execute[install-key 42550abd1E80D7C1BC0BAD851285491434D8786F] due to not_if ruby block
```
