### PR TITLE
Try to redownload apt key if failed for some reanson

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -55,6 +55,8 @@ def install_key_from_uri(uri)
     remote_file cached_keyfile do
       source new_resource.key
       mode 00644
+      retries 5
+      retry_delay 2
       action :create
     end
   else


### PR DESCRIPTION
I had a situation where downloading apt key fails form time to time 

```
Errno::ETIMEDOUT: Error connecting to https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc - Connection timed out - connect(2)
```

adding retries seems to fix the issue.
