### PR TITLE
compatible with chef version < 11

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 
-use_inline_resources
+if Chef::VERSION.to_i >= 11
+  use_inline_resources
+end
 
 def whyrun_supported?
   true


### PR DESCRIPTION
making code compatible with chef version lower than 11, to make this package work with vagrant and its default box running chef 10.14.2
im not sure if this breaks the functionality, but with this change im able to successfully use this cookbook. however im not interacting with repositories in any way.
