### PR TITLE
Check if "use_inline_resources" method is defined

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-use_inline_resources
+use_inline_resources if defined?(use_inline_resources)
 
 def whyrun_supported?
   true


### PR DESCRIPTION
On some versions of Chef (10.16.6 in my case) 'use_inline_resources' might not be defined.

Currently it produces error:

```
NameError
---------
undefined local variable or method `use_inline_resources' for #<Class:0x7ff6be572cd8>
```

Fix taken from https://github.com/opscode-cookbooks/ark/pull/25
