### PR TITLE
Added ignore failure directive to "update-notifier-common" section

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,6 +46,7 @@ end
 
 # provides /var/lib/apt/periodic/update-success-stamp on apt-get update
 package "update-notifier-common" do
+  ignore_failure true
   notifies :run, 'execute[apt-get-update]', :immediately
 end
 


### PR DESCRIPTION
"apt-get update" command is intended to continue chef execution in case of apt-get update failure. Nevertheless the script throws an exception when the update failure occurs when the update is executed from "update-notifier-common" section. I added the `ignore_failure true` directive in order to ignore the update problems in "update-notifier-common" as well.
