### PR TITLE
Make `apt-key` work from behind firewall

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -29,7 +29,7 @@ def install_key_from_keyserver(key, keyserver)
     if !node['apt']['key_proxy'].empty?
       command "apt-key adv --keyserver-options http-proxy=#{node['apt']['key_proxy']} --keyserver hkp://#{keyserver}:80 --recv #{key}"
     else
-      command "apt-key adv --keyserver #{keyserver} --recv #{key}"
+      command "apt-key adv --keyserver hkp://#{keyserver}:80 --recv #{key}"
     end
     action :run
     not_if do


### PR DESCRIPTION
Hi! I had trouble getting the apt recipe to work from our company network, and I encountered this blog post: http://lodge.glasgownet.com/2012/07/11/apt-key-from-behind-a-firewall/. Its author describes that including a schema and port for the `--keyserver` parameter fixes things. I made a change in repository.rb accordingly and indeed, Things were Fixed (tm).

My understanding is that this change can never hurt, but admittedly I am not completely familiar with the impact of this change. I see that two lines above, when proxy settings are given, you do include a schema and port.

If you agree that this is a non-breaking change, will you accept my pull request? Thanks!
