### PR TITLE
Fix FC003 problem

### DIFF
--- a/recipes/cacher-client.rb
+++ b/recipes/cacher-client.rb
@@ -47,7 +47,11 @@ unless (Chef::Config[:solo] || servers.length > 0)
   query = "apt_caching_server:true"
   query += " AND chef_environment:#{node.chef_environment}" if node['apt']['cacher-client']['restrict_environment']
   Chef::Log.debug("apt::cacher-client searching for '#{query}'")
-  servers += search(:node, query)
+    if Chef::Config[:solo]
+    Chef::Log.warn("This recipe uses search. Chef Solo does not support search.")
+  else
+    servers += search(:node, query)
+  end
 end
 
 if servers.length > 0


### PR DESCRIPTION
Before:
$ foodcritic -f any apt
FC003: Check whether you are running with chef server before using server-specific features: apt_opscode/recipes/cacher-client.rb:50

After:
$ foodcritic -f any apt

$
