### PR TITLE
[COOK-4512] Bugfix: Use empty PATH if PATH is nil

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -31,6 +31,7 @@ module Apt
     #
     # @return [String, nil]
     def which(cmd)
+      ENV["PATH"] = "" if ENV["PATH"].nil?
       paths = (ENV['PATH'].split(::File::PATH_SEPARATOR) + %w(/bin /usr/bin /sbin /usr/sbin))
 
       paths.each do |path|


### PR DESCRIPTION
Using AWS Opsworks with Chef 11.10 has a nil `ENV['PATH']`, so `which` fails on split. This sets an empty PATH variable if it is nil.

See also: https://tickets.opscode.com/browse/CHEF-4358

[COOK-4512]
