### PR TITLE
COOK-4534: Add option to update apt cache at compiletime

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Attributes
 * `['apt']['cacher_dir']` - directory used by cacher-ng service, default is '/var/cache/apt-cacher-ng'
 * `['apt']['cacher-client']['restrict_environment']` - restrict your node to using the `apt-cacher-ng` server in your Environment, default is 'false'
 * `['apt']['compiletime']` - force the `cacher-client` recipe to run before other recipes. It forces apt to use the proxy before other recipes run. Useful if your nodes have limited access to public apt repositories. This is overridden if the `cacher-ng` recipe is in your run list. Default is 'false'
+* `['apt']['compile_time_update']` - force the default recipe to run `apt-get update` at compile time.
 * `['apt']['cache_bypass']` - array of URLs to bypass the cache. Accepts the URL and protocol to  fetch directly from the remote repository and not attempt to cache
 * `['apt']['periodic_update_min_delay']` - minimum delay (in seconds) beetween two actual executions of `apt-get update` by the `execute[apt-get-update-periodic]` resource, default is '86400' (24 hours)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,6 +23,7 @@ default['apt']['cacher_interface'] = nil
 default['apt']['cacher_port'] = 3142
 default['apt']['caching_server'] = false
 default['apt']['compiletime'] = false
+default['apt']['compile_time_update'] = false
 default['apt']['key_proxy'] = ''
 default['apt']['cache_bypass'] = {}
 default['apt']['periodic_update_min_delay'] = 86_400

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,6 +25,15 @@
 
 Chef::Log.debug 'apt is not installed. Apt-specific resources will not be executed.' unless apt_installed?
 
+# If compile_time_update run apt-get update at compile time
+e = execute 'apt-get-update' do
+  command 'apt-get update'
+  ignore_failure true
+  only_if { apt_installed? }
+  action :nothing
+end
+e.run_action(:run) if node['apt']['compile_time_update']
+
 # Run apt-get update to create the stamp file
 execute 'apt-get-update' do
   command 'apt-get update'


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4534

This pull-request adds a `compile_time_update` attribute to the Apt cookbook to force an `apt-get update` at compile time in order to ensure cookbooks that have an option to run at compile time can install packages. I used `compile_time_update` because `compiletime` is already being used for a different functionality. However, in the future, it may be useful to refactor these into attributes that are more obvious.
##### History

Changes in the build-essential cookbook (discussed [here](https://github.com/opscode-cookbooks/build-essential/pull/32)) have removed build-essential's behavior of running `apt-get update` before attempting to install packages when invoked at compile time. Per the linked discussion in the build-essential cookbook, @sethvargo recommended updating the Apt cookbook to provide an option to run at compile time instead of build-essential being responsible for it.
