### PR TITLE
Files in preferences.d dir should have extension .pref or non

### DIFF
--- a/providers/preference.rb
+++ b/providers/preference.rb
@@ -39,7 +39,7 @@ action :add do
     action :nothing
   end
 
-  preference_file = file "/etc/apt/preferences.d/#{new_resource.name}" do
+  preference_file = file "/etc/apt/preferences.d/#{new_resource.name}.pref" do
     owner 'root'
     group 'root'
     mode 00644


### PR DESCRIPTION
Note that the files in the /etc/apt/preferences.d directory are parsed in alphanumeric ascending order and need to obey the following naming convention: The files have either no or "pref" as filename extension and only contain alphanumeric, hyphen (-), underscore (_) and period (.) characters. Otherwise APT will print a notice that it has ignored a file, unless that file matches a pattern in the Dir::Ignore-Files-Silently configuration list - in which case it will be silently ignored.
