### PR TITLE
Remove old preference files without .pref extension from previous versions

### DIFF
--- a/providers/preference.rb
+++ b/providers/preference.rb
@@ -41,6 +41,9 @@ action :add do
 
   preference_old_file = file "/etc/apt/preferences.d/#{new_resource.name}" do
     action :nothing
+    if ::File.exists?("/etc/apt/preferences.d/#{new_resource.name}")
+      Chef::Log.warn "Replacing #{new_resource.name} with #{new_resource.name}.pref in /etc/apt/preferences.d/"
+    end
   end
 
   preference_file = file "/etc/apt/preferences.d/#{new_resource.name}.pref" do


### PR DESCRIPTION
Hi,

the last change by @Alukardd leaves old preference files in /etc/apt/preferences.d/ without .pref extension. This might have some impact on how apt prioritizes the pinned versions or pin packages to a wrong version / priority.

Cheers,
Jan
