### PR TITLE
Install the mailutils package in the unattended-upgrades recipe if the mail attribute is set to true

### DIFF
--- a/recipes/unattended-upgrades.rb
+++ b/recipes/unattended-upgrades.rb
@@ -28,6 +28,10 @@ package 'unattended-upgrades' do
   action :install
 end
 
+if node['apt']['unattended_upgrades']['mail']
+  package 'mailutils'
+end
+
 template '/etc/apt/apt.conf.d/20auto-upgrades' do
   owner 'root'
   group 'root'


### PR DESCRIPTION
This ensures that the server will be capable of sending the emails after performing the upgrades.

This was inspired by another cookbook that handled unattended-upgrades:
https://github.com/firstbanco/chef-unattended-upgrades/blob/13b0b86386d87ee4d19ae62451ca7f37b9c87d02/recipes/default.rb#L5-L7
