### PR TITLE
Support for handling sources.list in ubuntu and debian - reprise

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -60,3 +60,15 @@ suites:
         unattended_upgrades:
           enable: true
 
+  - name: sources_list
+    run_list:
+      - recipe[minitest-handler]
+      - recipe[apt_test::sources_list]
+    attributes:
+      apt:
+        sources_list:
+          enable_cdn: true
+          ubuntu:
+            enable_partners: true
+          debian:
+            enable_backports: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,7 +2,7 @@ driver:
   name: vagrant
 
 platforms:
-  - name: debian-7.2.0
+  - name: debian-7.8
     run_list: apt::default
   # - name: debian-8.0
   #   run_list: apt::default

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Installs and configures the `unattended-upgrades` package to provide automatic p
 
 To pull just security updates, you'd set `allowed_origins` to something link `["Ubuntu trusty-security"]` (for Ubuntu trusty) or `["Debian wheezy-security"]` (for Debian wheezy). 
 
+### sources_list
+
+Configure the `/etc/apt/sources.list` file according to the attributes set in `['apt']['sources_list']`.
 
 Attributes
 ----------
@@ -116,6 +119,31 @@ Attributes
 * `['apt']['unattended_upgrades']['remove_unused_dependencies']` Do automatic removal of new unused dependencies after the upgrade. Defaults to false.
 * `['apt']['unattended_upgrades']['automatic_reboot']` — Automatically reboots *without confirmation* if a restart is required after the upgrade. Defaults to false.
 * `['apt']['unattended_upgrades']['dl_limit']` — Limits the bandwidth used by apt to download packages. Value given as an integer in kb/sec. Defaults to nil (no limit).
+
+### sources.list
+
+* `['apt']['sources_list']['include_source_packages']` — Add deb-src entries. Defaults to true.
+* `['apt']['sources_list']['enable_cdn']` — Use a Content Distribution Network to automatically use mirrors nears you. Default to false.
+
+#### sources.list for Ubuntu
+
+* `['apt']['sources_list']['ubuntu']['cdn_url']` — The URL to use when CDN is enabled.
+* `['apt']['sources_list']['ubuntu']['archive_url']` — The URL of the default Ubuntu mirror.
+* `['apt']['sources_list']['ubuntu']['security_url']` — The URL of the default Ubuntu security mirror.
+* `['apt']['sources_list']['ubuntu']['partners_url']` — The URL of the default Ubuntu partner mirror.
+* `['apt']['sources_list']['ubuntu']['components']` — The components to enable for Ubuntu repositories. Defaults to 'main restricted universe multiverse'.
+* `['apt']['sources_list']['ubuntu']['enable_updates']` — Enables the Ubuntu updates repository. Defaults to true.
+* `['apt']['sources_list']['ubuntu']['enable_backports'] ` — Enables the Ubuntu backports repository. Defaults to true.
+* `['apt']['sources_list']['ubuntu']['enable_partners']` — Enables the Ubuntu partners repository. Defaults to false.
+
+#### source.list for Debian
+
+* `['apt']['sources_list']['debian']['cdn_url']` — The URL to use when CDN is enabled.
+* `['apt']['sources_list']['debian']['archive_url']` — The URL of the default Debian mirror.
+* `['apt']['sources_list']['debian']['security_url']` — The URL of the default Debian security mirror.
+* `['apt']['sources_list']['debian']['components']` — The components to enable for Debian repositories. Defaults to 'main contrib non-free'.
+* `['apt']['sources_list']['debian']['enable_updates']` — Enables the Debian updates repository. Defaults to true.
+* `['apt']['sources_list']['debian']['enable_backports']` — Enables the Debian backports repository. Defaults to false.
 
 Libraries
 ---------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,3 +46,23 @@ default['apt']['unattended_upgrades']['remove_unused_dependencies'] = false
 default['apt']['unattended_upgrades']['automatic_reboot'] = false
 default['apt']['unattended_upgrades']['automatic_reboot_time'] = 'now'
 default['apt']['unattended_upgrades']['dl_limit'] = nil
+
+
+default['apt']['sources_list']['include_source_packages'] = true
+default['apt']['sources_list']['enable_cdn'] = false
+
+default['apt']['sources_list']['ubuntu']['cdn_url'] = 'mirror://mirrors.ubuntu.com/mirrors.txt'
+default['apt']['sources_list']['ubuntu']['archive_url']  = 'http://us.archive.ubuntu.com/ubuntu'
+default['apt']['sources_list']['ubuntu']['security_url'] = 'http://security.ubuntu.com/ubuntu'
+default['apt']['sources_list']['ubuntu']['partners_url'] = 'http://archive.canonical.com/ubuntu'
+default['apt']['sources_list']['ubuntu']['components'] = 'main restricted universe multiverse'
+default['apt']['sources_list']['ubuntu']['enable_updates'] = true
+default['apt']['sources_list']['ubuntu']['enable_backports'] = true
+default['apt']['sources_list']['ubuntu']['enable_partners'] = false
+
+default['apt']['sources_list']['debian']['cdn_url']  = 'http://httpredir.debian.org/debian'
+default['apt']['sources_list']['debian']['archive_url']  = 'http://mirrors.kernel.org/debian'
+default['apt']['sources_list']['debian']['security_url'] = 'http://security.debian.org/'
+default['apt']['sources_list']['debian']['components'] = 'main contrib non-free'
+default['apt']['sources_list']['debian']['enable_updates'] = true
+default['apt']['sources_list']['debian']['enable_backports'] = false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,7 +47,6 @@ default['apt']['unattended_upgrades']['automatic_reboot'] = false
 default['apt']['unattended_upgrades']['automatic_reboot_time'] = 'now'
 default['apt']['unattended_upgrades']['dl_limit'] = nil
 
-
 default['apt']['sources_list']['include_source_packages'] = true
 default['apt']['sources_list']['enable_cdn'] = false
 

--- a/recipes/sources_list.rb
+++ b/recipes/sources_list.rb
@@ -9,11 +9,11 @@ end
 template_hash = {
   :codename => node['lsb']['codename'],
   :sources => node['apt']['sources_list']['include_source_packages'],
-  :archive_url => node['apt']['sources_list']["#{platform}"]["#{repo}_url"],
-  :security_url => node['apt']['sources_list']["#{platform}"]['security_url'],
-  :components => node['apt']['sources_list']["#{platform}"]['components'],
-  :updates => node['apt']['sources_list']["#{platform}"]['enable_updates'],
-  :backports => node['apt']['sources_list']["#{platform}"]['enable_backports'],
+  :archive_url => node['apt']['sources_list'][platform]["#{repo}_url"],
+  :security_url => node['apt']['sources_list'][platform]['security_url'],
+  :components => node['apt']['sources_list'][platform]['components'],
+  :updates => node['apt']['sources_list'][platform]['enable_updates'],
+  :backports => node['apt']['sources_list'][platform]['enable_backports'],
 }
 
 if node['platform'] == 'ubuntu'

--- a/recipes/sources_list.rb
+++ b/recipes/sources_list.rb
@@ -2,9 +2,7 @@
 platform = node['platform']
 
 repo = 'archive'
-if node['apt']['sources_list']['enable_cdn']
-  repo = 'cdn'
-end
+repo = 'cdn' if node['apt']['sources_list']['enable_cdn']
 
 template_hash = {
   :codename => node['lsb']['codename'],
@@ -21,11 +19,11 @@ if node['platform'] == 'ubuntu'
   template_hash[:partners_url] = node['apt']['sources_list']['ubuntu']['partners_url']
 end
 
-template "/etc/apt/sources.list" do
-    mode 00644
-    variables template_hash
-    owner 'root'
-    group 'root'
-    notifies :run, 'execute[apt-get update]', :immediately
-    source "sources.list.erb"
+template '/etc/apt/sources.list' do
+  mode 00644
+  variables template_hash
+  owner 'root'
+  group 'root'
+  notifies :run, 'execute[apt-get update]', :immediately
+  source 'sources.list.erb'
 end

--- a/recipes/sources_list.rb
+++ b/recipes/sources_list.rb
@@ -1,0 +1,31 @@
+
+platform = node['platform']
+
+repo = 'archive'
+if node['apt']['sources_list']['enable_cdn']
+  repo = 'cdn'
+end
+
+template_hash = {
+  :codename => node['lsb']['codename'],
+  :sources => node['apt']['sources_list']['include_source_packages'],
+  :archive_url => node['apt']['sources_list']["#{platform}"]["#{repo}_url"],
+  :security_url => node['apt']['sources_list']["#{platform}"]['security_url'],
+  :components => node['apt']['sources_list']["#{platform}"]['components'],
+  :updates => node['apt']['sources_list']["#{platform}"]['enable_updates'],
+  :backports => node['apt']['sources_list']["#{platform}"]['enable_backports'],
+}
+
+if node['platform'] == 'ubuntu'
+  template_hash[:partners] = node['apt']['sources_list']['ubuntu']['enable_partners']
+  template_hash[:partners_url] = node['apt']['sources_list']['ubuntu']['partners_url']
+end
+
+template "/etc/apt/sources.list" do
+    mode 00644
+    variables template_hash
+    owner 'root'
+    group 'root'
+    notifies :run, 'execute[apt-get update]', :immediately
+    source "sources.list.erb"
+end

--- a/templates/debian/sources.list.erb
+++ b/templates/debian/sources.list.erb
@@ -1,0 +1,17 @@
+# Managed by Chef
+
+deb <%= @archive_url %> <%= @codename %> <%= @components %>
+<% if @sources -%>deb-src <%= @archive_url %> <%= @codename %> <%= @components %><% end -%>
+
+deb <%= @security_url %> <%= @codename %>/updates <%= @components %>
+<% if @sources -%>deb-src <%= @security_url %> <%= @codename %>/updates <%= @components %><% end -%>
+
+<% if @updates -%>
+deb <%= @archive_url %> <%= @codename %>-updates <%= @components %>
+<% if @sources -%>deb-src <%= @archive_url %> <%= @codename %>-updates <%= @components %><% end -%>
+<% end -%>
+
+<% if @backports -%>
+deb <%= @archive_url %> <%= @codename %>-backports <%= @components %>
+<% if @sources -%>deb-src <%= @archive_url %> <%= @codename %>-backports <%= @components %><% end -%>
+<% end -%>

--- a/templates/ubuntu/sources.list.erb
+++ b/templates/ubuntu/sources.list.erb
@@ -1,0 +1,22 @@
+# Managed by Chef
+
+deb <%= @archive_url %> <%= @codename %> <%= @components %>
+<% if @sources -%>deb-src <%= @archive_url %> <%= @codename %> <%= @components %><% end -%>
+
+deb <%= @security_url %> <%= @codename %>-security <%= @components %>
+<% if @sources -%>deb-src <%= @security_url %> <%= @codename %>-security <%= @components %><% end -%>
+
+<% if @updates -%>
+deb <%= @archive_url %> <%= @codename %>-updates <%= @components %>
+<% if @sources -%>deb-src <%= @archive_url %> <%= @codename %>-updates <%= @components %><% end -%>
+<% end -%>
+
+<% if @backports -%>
+deb <%= @archive_url %> <%= @codename %>-backports <%= @components %>
+<% if @sources -%>deb-src <%= @archive_url %> <%= @codename %>-backports <%= @components %><% end -%>
+<% end -%>
+
+<% if @partners -%>
+deb <%= @partners_url %> <%= @codename %> partner
+<% if @sources -%>deb-src <%= @partners_url %> <%= @codename %> partner<% end -%>
+<% end -%>

--- a/test/cookbooks/apt_test/files/default/tests/minitest/sources_list_test.rb
+++ b/test/cookbooks/apt_test/files/default/tests/minitest/sources_list_test.rb
@@ -30,5 +30,4 @@ describe 'apt_test::sources_list' do
     it { config.must_match(/^# Managed by Chef$/) }
     it { config.must_match(/(lucid|precise|trusty|utopic|vivid|wheezy)/) }
   end
-
 end

--- a/test/cookbooks/apt_test/files/default/tests/minitest/sources_list_test.rb
+++ b/test/cookbooks/apt_test/files/default/tests/minitest/sources_list_test.rb
@@ -1,0 +1,34 @@
+#
+# Cookbook Name:: apt_test
+# Recipe:: lwrps
+#
+# Copyright 2012, Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require File.expand_path('../support/helpers', __FILE__)
+
+describe 'apt_test::sources_list' do
+  include Helpers::AptTest
+
+  describe 'creates sources.list and has proper permissions' do
+    let(:config) { file("/etc/apt/sources.list") }
+    it { config.must_have(:mode, "644") }
+    it { config.must_have(:owner, "root") }
+    it { config.must_have(:group, "root") }
+    it { config.must_match /^# Managed by Chef$/}
+    it { config.must_match /(lucid|precise|trusty|utopic|vivid|wheezy)/}
+  end
+
+end

--- a/test/cookbooks/apt_test/files/default/tests/minitest/sources_list_test.rb
+++ b/test/cookbooks/apt_test/files/default/tests/minitest/sources_list_test.rb
@@ -23,12 +23,12 @@ describe 'apt_test::sources_list' do
   include Helpers::AptTest
 
   describe 'creates sources.list and has proper permissions' do
-    let(:config) { file("/etc/apt/sources.list") }
-    it { config.must_have(:mode, "644") }
-    it { config.must_have(:owner, "root") }
-    it { config.must_have(:group, "root") }
-    it { config.must_match /^# Managed by Chef$/}
-    it { config.must_match /(lucid|precise|trusty|utopic|vivid|wheezy)/}
+    let(:config) { file('/etc/apt/sources.list') }
+    it { config.must_have(:mode, '644') }
+    it { config.must_have(:owner, 'root') }
+    it { config.must_have(:group, 'root') }
+    it { config.must_match(/^# Managed by Chef$/) }
+    it { config.must_match(/(lucid|precise|trusty|utopic|vivid|wheezy)/) }
   end
 
 end

--- a/test/cookbooks/apt_test/recipes/sources_list.rb
+++ b/test/cookbooks/apt_test/recipes/sources_list.rb
@@ -1,1 +1,1 @@
-include_recipe "apt::sources_list"
+include_recipe 'apt::sources_list'

--- a/test/cookbooks/apt_test/recipes/sources_list.rb
+++ b/test/cookbooks/apt_test/recipes/sources_list.rb
@@ -1,0 +1,1 @@
+include_recipe "apt::sources_list"


### PR DESCRIPTION
This is a rework of the original PR #102 

Now the used attributes are similar to the [ubuntu cookbook attributes](https://github.com/opscode-cookbooks/ubuntu/blob/master/attributes/default.rb), actually deprecating it.

I've also added README and a minitest (no excuses for not getting it merged now :love_letter: ).