### PR TITLE
Allow apt::unattended-upgrade to support debian platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ v2.9.0 (Unreleased)
 - Add `sensitive` flag for apt\_repositories
 - Enable installation of recommended or suggested packages
 - Tidy up `apt-get update` logic
+- Make `Allowed-Origins` compatible with debian systems for
+  `apt::unattended-upgrade`.[[GH-163]](https://github.com/chef-cookbooks/apt/issues/162)
 
 v2.8.2 (2015-08-24)
 -------------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,9 +33,15 @@ default['apt']['unattended_upgrades']['enable'] = false
 default['apt']['unattended_upgrades']['update_package_lists'] = true
 # this needs a good default
 codename = node.attribute?('lsb') ? node['lsb']['codename'] : 'notlinux'
-default['apt']['unattended_upgrades']['allowed_origins'] = [
-  "#{node['platform'].capitalize} #{codename}"
-]
+archive = case node['platform']
+          when 'debian'
+            case codename
+            when 'wheezy' then 'oldstable'
+            when 'jessie' then 'stable'
+            end
+          when 'ubuntu' then '${distro_codename}'
+          end
+default['apt']['unattended_upgrades']['allowed_origins'] = ["${distro_id} #{archive}"]
 default['apt']['unattended_upgrades']['package_blacklist'] = []
 default['apt']['unattended_upgrades']['auto_fix_interrupted_dpkg'] = false
 default['apt']['unattended_upgrades']['minimal_steps'] = false


### PR DESCRIPTION
The archive name is not the codename on debian, but `stable` or `oldstable`, depending on the release.

PR forthcoming