### PR TITLE
Adds the option to retry adding failing remote keys

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -49,6 +49,10 @@ suites:
   - name: lwrps
     run_list:
       - recipe[apt_test::lwrps]
+    attributes:
+      apt:
+        keyserver_retries: 3
+        keyserver_retry_delay: 5
 
   - name: unattended-upgrades
     run_list:
@@ -57,4 +61,3 @@ suites:
       apt:
         unattended_upgrades:
           enable: true
-

--- a/README.md
+++ b/README.md
@@ -78,13 +78,19 @@ If you wish to help the `cacher-ng` recipe seed itself, you must now explicitly 
 
 Installs and configures the `unattended-upgrades` package to provide automatic package updates. This can be configured to upgrade all packages or to just install security updates by setting `['apt']['unattended_upgrades']['allowed_origins']`.
 
-To pull just security updates, you'd set `allowed_origins` to something link `["Ubuntu trusty-security"]` (for Ubuntu trusty) or `["Debian wheezy-security"]` (for Debian wheezy). 
+To pull just security updates, you'd set `allowed_origins` to something link `["Ubuntu trusty-security"]` (for Ubuntu trusty) or `["Debian wheezy-security"]` (for Debian wheezy).
 
+### keyserver_retries
+Instructs chef to retry fetching the keyfile from a remote repository on failure.
+This attribute accepts an integer as a value on how many times it should retry to fetch the remote file.
+
+### keyserver_retry_delay
+Sets the delay (in seconds) in between the keyserver_retries as mentioned above.
 
 Attributes
 ----------
 
-### General 
+### General
 * `['apt']['compile_time_update']` - force the default recipe to run `apt-get update` at compile time.
 * `['apt']['periodic_update_min_delay']` - minimum delay (in seconds) beetween two actual executions of `apt-get update` by the `execute[apt-get-update-periodic]` resource, default is '86400' (24 hours)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -49,3 +49,6 @@ default['apt']['unattended_upgrades']['dl_limit'] = nil
 
 default['apt']['confd']['install_recommends'] = true
 default['apt']['confd']['install_suggests'] = false
+
+default['apt']['keyserver_retries'] = 0
+default['apt']['keyserver_retry_delay'] = 0

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Configures apt and apt services and LWRPs for managing apt reposito
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/chef-cookbooks/apt/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/chef-cookbooks/apt' if respond_to?(:source_url)
-version '2.8.2'
+version '2.9.0'
 recipe 'apt', 'Runs apt-get update during compile phase and sets up preseed directories'
 recipe 'apt::cacher-ng', 'Set up an apt-cacher-ng caching proxy'
 recipe 'apt::cacher-client', 'Client for the apt::cacher-ng caching proxy'

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -39,7 +39,6 @@ def install_key_from_keyserver(key, keyserver, key_proxy)
       key_present = extract_fingerprints_from_cmd('apt-key finger').any? do |fingerprint|
         fingerprint.end_with?(key.upcase)
       end
-
       key_present && key_is_valid('apt-key list', key.upcase)
     end
   end
@@ -89,6 +88,8 @@ def install_key_from_uri(uri)
     remote_file cached_keyfile do
       source new_resource.key
       mode 00644
+      retries new_resource.keyserver_retries
+      retry_delay new_resource.keyserver_retry_delay
       sensitive new_resource.sensitive if respond_to?(:sensitive)
       action :create
     end

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -38,7 +38,9 @@ state_attrs :arch,
             :repo_name,
             :trusted,
             :uri,
-            :sensitive
+            :sensitive,
+            :keyserver_retries,
+            :keyserver_retry_delay
 
 # name of the repo, used for source.list filename
 attribute :repo_name, kind_of: String, name_attribute: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.)+$/]
@@ -53,6 +55,8 @@ attribute :keyserver, kind_of: String, default: nil
 attribute :key, kind_of: String, default: nil
 attribute :key_proxy, kind_of: String, default: node['apt']['key_proxy']
 attribute :cookbook, kind_of: String, default: nil
+attribute :keyserver_retries, Integer, default: node['apt']['keyserver_retries']
+attribute :keyserver_retry_delay, Integer, default: node['apt']['keyserver_retry_delay']
 # trigger cache rebuild
 # If not you can trigger in the recipe itself after checking the status of resource.updated{_by_last_action}?
 attribute :cache_rebuild, kind_of: [TrueClass, FalseClass], default: true


### PR DESCRIPTION
This patch makes it possible to retry fetching a failed keyfile from a
remote server.

Example error:

```
================================================================================
Error executing action `add` on resource 'apt_repository[nginx]'
================================================================================
Errno::ENETUNREACH
------------------
remote_file[/tmp/kitchen/cache/nginx_signing.key] (/tmp/kitchen/cache/cookbooks/apt/providers/repository.rb line 86) had an error: Errno::ENETUNREACH: Network is unreachable - connect(2) for "nginx.org" port 80
Resource Declaration:
---------------------
4: apt_repository 'nginx' do
5:   uri "http://nginx.org/packages/#{node['platform']}"
6:   distribution node['lsb']['codename']
7:   components %w(nginx)
8:   key 'http://nginx.org/packages/keys/nginx_signing.key'
9:   only_if { node['nginx']['package'] == 'nginx' }
10:   not_if { node['recipes'].include? 'passenger' }
11: end
12:
```

By setting the node attributes keyserver_retries and keyserver_retry_delay you can determine how many times the action should be retried, or how many delay there should be between each retry.
