### PR TITLE
Allow + in a package name

### DIFF
--- a/resources/preference.rb
+++ b/resources/preference.rb
@@ -31,7 +31,7 @@ state_attrs :glob,
             :pin,
             :pin_priority
 
-attribute :package_name, kind_of: String, name_attribute: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.|\*)+$/]
+attribute :package_name, kind_of: String, name_attribute: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.|\*|\+)+$/]
 attribute :glob, kind_of: String
 attribute :pin, kind_of: String
 attribute :pin_priority, kind_of: String


### PR DESCRIPTION
I couldn't find formal definition of a package name but I've been using a package whose name contains `+` successfully.

As for contribution guideline, is it mandatory to create an account on chef supermarket?