### PR TITLE
Deprecate repo_name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This LWRP provides an easy way to manage additional APT repositories. Adding a n
 - :remove: removes the repository file
 
 #### Attribute Parameters
-- repo_name: name attribute. The name of the channel to discover
+- name: name attribute. The name of the channel to discover
 - uri: the base of the Debian distribution
 - distribution: this is usually your release's codename...ie something like `karmic`, `lucid` or `maverick`
 - components: package groupings... when in doubt use `main`

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache 2.0'
 description 'Configures apt and apt services. Ships resources for managing apt repositories'
 issues_url 'https://github.com/chef-cookbooks/apt/issues' if respond_to?(:issues_url)
 source_url 'https://github.com/chef-cookbooks/apt' if respond_to?(:source_url)
-version '2.9.2'
+version '2.9.3'
 
 recipe 'apt::default', 'Runs apt-get update during compile phase and sets up preseed directories'
 recipe 'apt::cacher-ng', 'Set up an apt-cacher-ng caching proxy'

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -35,13 +35,14 @@ state_attrs :arch,
             :key,
             :keyserver,
             :key_proxy,
-            :repo_name,
+            :name,
             :trusted,
             :uri,
             :sensitive
 
 # name of the repo, used for source.list filename
-attribute :repo_name, kind_of: String, name_attribute: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.)+$/]
+attribute :name, kind_of: String, name_attribute: true, regex: [/^([a-z]|[A-Z]|[0-9]|_|-|\.)+$/]
+attribute :repo_name, kind_of: String # Unused.  Present for backwards compatibility
 attribute :uri, kind_of: String
 attribute :distribution, kind_of: String
 attribute :components, kind_of: Array, default: []


### PR DESCRIPTION
Since repo_name is unused in the LWRP, it should not be a name attribute
either.  This commit deprecates it, but maintains its syntax.

This fixes https://github.com/chef-cookbooks/apt/issues/173