### PR TITLE
autoremove: always work non-interactively

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -70,6 +70,9 @@ end
 # Automatically remove packages that are no longer needed for dependencies
 execute 'apt-get autoremove' do
   command 'apt-get -y autoremove'
+  environment(
+    'DEBIAN_FRONTEND' => 'noninteractive'
+  )
   only_if { apt_installed? }
   action :nothing
 end


### PR DESCRIPTION
Some packages (e.g. libpam-ck-connector) attempt to present a dialog
when being removed, interrupting the convergence flow.  Ensure that
doesn't happen.