### PR TITLE
Removed the template code for 10recommends

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -74,14 +74,6 @@ end
   end
 end
 
-template '/etc/apt/apt.conf.d/10recommends' do
-  owner 'root'
-  group 'root'
-  mode '0644'
-  source '10recommends.erb'
-  only_if { apt_installed? }
-end
-
 package 'apt-transport-https' do
   only_if { apt_installed? }
 end


### PR DESCRIPTION
The following error was being thrown on running the 3.0.0 version of the cookbook:
default: File templates/default/10recommends.erb does not exist for cookbook apt

I removed the code in default.rb referencing this file since it no longer exists in files/default directory.