### PR TITLE
Normalize full key name to avoid resource update on identical key names

### DIFF
--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -84,7 +84,7 @@ end
 
 # install apt key from URI
 def install_key_from_uri(uri)
-  key_name = uri.split(%r{\/}).last
+  key_name = uri.gsub(/[^0-9A-Za-z\-]/, '_')
   cached_keyfile = "#{Chef::Config[:file_cache_path]}/#{key_name}"
   if new_resource.key =~ /http/
     remote_file cached_keyfile do


### PR DESCRIPTION
### Description

We have multiple apt repositories that have key names similar enough so the cookbook treats them as the same when performs `remote_file` cache (due to regex below).

### Issues Resolved

This PR makes sure that `remote_file` caches remote key with a unique name and thus avoids updating resources on every chef run.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] The CLA has been signed.
