### PR TITLE
Fix noop for apt_update on non-apt platforms.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,7 +30,7 @@ file '/var/lib/apt/periodic/update-success-stamp' do
 end
 
 # If compile_time_update run apt-get update at compile time
-if node['apt']['compile_time_update']
+if node['apt']['compile_time_update'] && apt_installed?
   apt_update('compile time').run_action(:periodic)
 end
 


### PR DESCRIPTION
### Description

Fix noop for apt_update on non-apt platforms.

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


