### PR TITLE
avoid CHEF-3694 in apt_preference resource

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Configures apt and apt services. Ships resources for managing apt repositories'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '5.0.0'
+version '5.0.1'
 
 recipe 'apt::default', 'Runs apt-get update during compile phase and sets up preseed directories'
 recipe 'apt::cacher-ng', 'Set up an apt-cacher-ng caching proxy'

--- a/providers/preference.rb
+++ b/providers/preference.rb
@@ -49,7 +49,8 @@ action :add do
 
   name = safe_name(new_resource.name)
 
-  file "/etc/apt/preferences.d/#{new_resource.name}.pref" do
+  file "cleanup_#{new_resource.name}.pref" do
+    path "/etc/apt/preferences.d/#{new_resource.name}.pref"
     action :delete
     if ::File.exist?("/etc/apt/preferences.d/#{new_resource.name}.pref")
       Chef::Log.warn "Replacing #{new_resource.name}.pref with #{name}.pref in /etc/apt/preferences.d/"
@@ -57,7 +58,8 @@ action :add do
     only_if { name != new_resource.name }
   end
 
-  file "/etc/apt/preferences.d/#{new_resource.name}" do
+  file "cleanup_#{new_resource.name}" do
+    path "/etc/apt/preferences.d/#{new_resource.name}"
     action :delete
     if ::File.exist?("/etc/apt/preferences.d/#{new_resource.name}")
       Chef::Log.warn "Replacing #{new_resource.name} with #{new_resource.name}.pref in /etc/apt/preferences.d/"
@@ -77,7 +79,8 @@ action :remove do
   name = safe_name(new_resource.name)
   if ::File.exist?("/etc/apt/preferences.d/#{name}.pref")
     Chef::Log.info "Un-pinning #{name} from /etc/apt/preferences.d/"
-    file "/etc/apt/preferences.d/#{name}.pref" do
+    file "remove_#{name}.pref" do
+      path "/etc/apt/preferences.d/#{name}.pref"
       action :delete
     end
   end


### PR DESCRIPTION
### Description

This avoids CHEF-3694 (Cloning resource attributes from prior resource) warnings when using apt_preferences.

### Issues Resolved

https://github.com/chef-cookbooks/apt/issues/170

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

