### PR TITLE
Confdef

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ To pull just security updates, set `origins_patterns` to something like `["origi
 
 ### Configuration for APT
 
+- `['apt']['confd']['force_confask']` - Prompt when overwriting configuration files. (default: false)
+- `['apt']['confd']['force_confdef']` - Don't prompt when overwriting configuration files. (default: false)
+- `['apt']['confd']['force_confmiss']` - Install removed configuration files when upgrading packages. (default: false)
+- `['apt']['confd']['force_confnew']` - Overwrite configuration files when installing packages. (default: false)
+- `['apt']['confd']['force_confold']` - Keep modified configuration files when installing packages. (default: false)
 - `['apt']['confd']['install_recommends']` - Consider recommended packages as a dependency for installing. (default: true)
 - `['apt']['confd']['install_suggests']` - Consider suggested packages as a dependency for installing. (default: false)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -48,5 +48,10 @@ default['apt']['unattended_upgrades']['automatic_reboot_time'] = 'now'
 default['apt']['unattended_upgrades']['dl_limit'] = nil
 default['apt']['unattended_upgrades']['random_sleep'] = nil
 
+default['apt']['confd']['force_confask'] = false
+default['apt']['confd']['force_confdef'] = false
+default['apt']['confd']['force_confmiss'] = false
+default['apt']['confd']['force_confnew'] = false
+default['apt']['confd']['force_confold'] = false
 default['apt']['confd']['install_recommends'] = true
 default['apt']['confd']['install_suggests'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -74,6 +74,14 @@ end
   end
 end
 
+template '/etc/apt/apt.conf.d/10dpkg-options' do
+  owner 'root'
+  group 'root'
+  mode '0644'
+  source '10dpkg-options.erb'
+  only_if { apt_installed? }
+end
+
 template '/etc/apt/apt.conf.d/10recommends' do
   owner 'root'
   group 'root'

--- a/templates/default/10dpkg-options.erb
+++ b/templates/default/10dpkg-options.erb
@@ -1,0 +1,8 @@
+# Managed by Chef
+Dpkg::Options {
+<%= node['apt']['confd']['force_confask'] ? '"--force-confask";' : '' -%>
+<%= node['apt']['confd']['force_confdef'] ? '"--force-confdef";' : '' -%>
+<%= node['apt']['confd']['force_confmiss'] ? '"--force-confmiss";' : '' -%>
+<%= node['apt']['confd']['force_confnew'] ? '"--force-confnew";' : '' -%>
+<%= node['apt']['confd']['force_confold'] ? '"--force-confold";' : '' -%>
+}

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -3,18 +3,32 @@ if os.name == 'debian' || os.name == 'ubuntu'
     it { should be_a_directory }
   end
 
-  content = [
+  content_dpkg_options = [
+    '# Managed by Chef',
+    'Dpkg::Options {',
+    '}',
+  ].join("\n") << "\n"
+
+  content_recommends = [
     '# Managed by Chef',
     'APT::Install-Recommends "1";',
     'APT::Install-Suggests "0";',
   ].join("\n") << "\n"
+
+  describe file('/etc/apt/apt.conf.d/10dpkg-options') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 0644 }
+    its(:content) { should eq content_dpkg_options }
+  end
 
   describe file('/etc/apt/apt.conf.d/10recommends') do
     it { should be_file }
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     it { should be_mode 0644 }
-    its(:content) { should eq content }
+    its(:content) { should eq content_recommends }
   end
 else
   describe file('/etc/apt/') do


### PR DESCRIPTION
### Description

Provides attribute control for what APT does when it encounters configuration file changes while managing packages. This can avoid errors like the following:

```
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
```

The general opinion seems to be that the combination of `--force-confdef` and `--force-confold` is the safest option for unattended installs but I left the default behavior as it was. Without setting any attributes it will still crash out with the above type error.

More information about the options is available from `man dpkg`, I tried to pare the descriptions down to something useful in the README.

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
