### PR TITLE
Use proper value type for bsd-mailx package only_if/not_if block

### DIFF
--- a/recipes/unattended-upgrades.rb
+++ b/recipes/unattended-upgrades.rb
@@ -29,7 +29,7 @@ package 'unattended-upgrades' do
 end
 
 package 'bsd-mailx' do
-  only_if { node['apt']['unattended_upgrades']['mail'] }
+  not_if { node['apt']['unattended_upgrades']['mail'].nil? }
 end
 
 template '/etc/apt/apt.conf.d/20auto-upgrades' do


### PR DESCRIPTION
Chef is throwing a warning when ["apt"]["unattended_upgrades"]["mail"] is set to non-nil value.

```
[2016-11-07T07:30:06+00:00] WARN: only_if block for apt_package[bsd-mailx] returned "singapore-paas@ragnarson.com", did you mean to run a command? If so use 'only_if "monitoring@example.com"' in your code.
```

Boolean value always should be use for a only_if/not_if block.

Signed-off-by: Szymon Szypulski <szymon.szypulski@gmail.com>