### PR TITLE
Remove wrong warning logs generated by apt_preference

### DIFF
--- a/recipes/cacher-client.rb
+++ b/recipes/cacher-client.rb
@@ -25,7 +25,7 @@ execute 'Remove proxy from /etc/apt/apt.conf' do
 end
 
 if node['apt']['cacher_client']['cacher_server'].empty?
-  Chef::Log.warn("No cache server defined in node['apt']['cacher_servers']. Not setting up caching")
+  Chef::Log.warn("No cache server defined in node['apt']['cacher_client']['cacher_server']. Not setting up caching")
   f = file '/etc/apt/apt.conf.d/01proxy' do
     action(node['apt']['compiletime'] ? :nothing : :delete)
   end

--- a/resources/preference.rb
+++ b/resources/preference.rb
@@ -42,7 +42,7 @@ action :add do
   file "cleanup_#{new_resource.name}.pref" do
     path "/etc/apt/preferences.d/#{new_resource.name}.pref"
     action :delete
-    if ::File.exist?("/etc/apt/preferences.d/#{new_resource.name}.pref")
+    if ::File.exist?("/etc/apt/preferences.d/#{new_resource.name}.pref") && name != new_resource.name
       Chef::Log.warn "Replacing #{new_resource.name}.pref with #{name}.pref in /etc/apt/preferences.d/"
     end
     only_if { name != new_resource.name }
@@ -52,7 +52,7 @@ action :add do
     path "/etc/apt/preferences.d/#{new_resource.name}"
     action :delete
     if ::File.exist?("/etc/apt/preferences.d/#{new_resource.name}")
-      Chef::Log.warn "Replacing #{new_resource.name} with #{new_resource.name}.pref in /etc/apt/preferences.d/"
+      Chef::Log.warn "Replacing #{new_resource.name} with #{name}.pref in /etc/apt/preferences.d/"
     end
   end
 


### PR DESCRIPTION
### Description

Remove wrong warnings generated by apt_preference.

### Issues Resolved

After upgrading out `apt` cookbook version from 2.7.0 to 6.1.0 we started to see many warnings in our chef-client logs during every run. In fact, chef wasn't doing any changes though.

```
[2017-06-20T11:50:48+00:00] WARN: Replacing jessie.pref with jessie.pref in /etc/apt/preferences.d/
[2017-06-20T11:50:48+00:00] WARN: Replacing jessie-backports.pref with jessie-backports.pref in /etc/apt/preferences.d/
```

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
