### PR TITLE
restore backwards compatability by respecting node['apt']['periodic_u…

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,10 +31,14 @@ end
 
 # If compile_time_update run apt-get update at compile time
 if node['apt']['compile_time_update'] && apt_installed?
-  apt_update('compile time').run_action(:periodic)
+  apt_update('compile time') do
+    frequency node['apt']['periodic_update_min_delay']
+  end.run_action(:periodic)
 end
 
-apt_update 'periodic'
+apt_update 'periodic' do
+  frequency node['apt']['periodic_update_min_delay']
+end
 
 # For other recipes to call to force an update
 execute 'apt-get update' do


### PR DESCRIPTION
…pdate_min_delay']

### Description

This restores the ability to tune the interval of periodic apt updates via node attributes

### Issues Resolved

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
