### PR TITLE
Restores ignore_failure true on compile time update.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,6 +33,7 @@ end
 if node['apt']['compile_time_update'] && apt_installed?
   apt_update('compile time') do
     frequency node['apt']['periodic_update_min_delay']
+    ignore_failure true
   end.run_action(:periodic)
 end
 


### PR DESCRIPTION
### Description

Commit c7d6b743c07e76d5c38c14f485ec4e74c93f9141 removed the
ignore_failure, causing some nodes with repo problems to fail in
compile time. As this resource can't be wrapped as it's executed in
compile time, it's safer to enable ignore_failure.


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>