### PR TITLE
[GH-237] Stop using deprecated matcher "contains"

### DIFF
--- a/test/integration/resources/resources_spec.rb
+++ b/test/integration/resources/resources_spec.rb
@@ -40,7 +40,7 @@ describe 'apt::resources' do
 
   it 'adds the JuJu package signing key' do
     skip('not on ubuntu') unless os.name == 'ubuntu'
-    expect(command('apt-key list').stdout).to contain('Launchpad Ensemble PPA')
+    expect(command('apt-key list').stdout).to include('Launchpad Ensemble PPA')
   end
 
   it 'creates the correct pinning preferences for chef' do


### PR DESCRIPTION
### Description

Removes the deprecated test matcher "contains" to fix the build

### Issues Resolved

Fixes #237 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
