### PR TITLE
Add syslog for unattended upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the apt cookbook.
 
+## 7.0.1 (2018-09-05)
+
+- Added support for the unattended-upgrade SyslogEnable configuration feature
+- Added support for the unattended-upgrade SyslogFacility configuration feature
+
 ## 7.0.0 (2018-04-06)
 
 ### Breaking Change

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ To pull just security updates, set `origins_patterns` to something like `["origi
 - `['apt']['unattended_upgrades']['automatic_reboot']` - Automatically reboots _without confirmation_ if a restart is required after the upgrade. Defaults to false.
 - `['apt']['unattended_upgrades']['dl_limit']` - Limits the bandwidth used by apt to download packages. Value given as an integer in kb/sec. Defaults to nil (no limit).
 - `['apt']['unattended_upgrades']['random_sleep']` - Wait a random number of seconds up to this value before running daily periodic apt actions. System default is 1800 seconds (30 minutes).
+- `['apt']['unattended_upgrades']['syslog_enable']` - Enable logging to syslog. Defaults to false.
+- `['apt']['unattended_upgrades']['syslog_facility']` - Specify syslog facility. Defaults to 'daemon'.
 
 ### Configuration for APT
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,8 @@ default['apt']['unattended_upgrades']['automatic_reboot'] = false
 default['apt']['unattended_upgrades']['automatic_reboot_time'] = 'now'
 default['apt']['unattended_upgrades']['dl_limit'] = nil
 default['apt']['unattended_upgrades']['random_sleep'] = nil
+default['apt']['unattended_upgrades']['syslog_enable'] = false
+default['apt']['unattended_upgrades']['syslog_facility'] = 'daemon'
 
 default['apt']['confd']['force_confask'] = false
 default['apt']['confd']['force_confdef'] = false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Configures apt and apt caching.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '7.0.0'
+version '7.0.1'
 
 recipe 'apt::default', 'Runs apt-get update during compile phase and sets up preseed directories'
 recipe 'apt::cacher-ng', 'Set up an apt-cacher-ng caching proxy'

--- a/templates/50unattended-upgrades.erb
+++ b/templates/50unattended-upgrades.erb
@@ -73,3 +73,9 @@ Unattended-Upgrade::Automatic-Reboot-Time "<%= node['apt']['unattended_upgrades'
 <% if node['apt']['unattended_upgrades']['dl_limit'] -%>
 Acquire::http::Dl-Limit "<%= node['apt']['unattended_upgrades']['dl_limit'] %>";
 <% end -%>
+
+// Enable logging to syslog. Default is False
+Unattended-Upgrade::SyslogEnable "<%= node['apt']['unattended_upgrades']['syslog_enable'] ? 'true' : 'false' %>";
+
+// Specify syslog facility. Default is daemon
+Unattended-Upgrade::SyslogFacility "<%= node['apt']['unattended_upgrades']['syslog_facility']";

--- a/templates/50unattended-upgrades.erb
+++ b/templates/50unattended-upgrades.erb
@@ -78,4 +78,4 @@ Acquire::http::Dl-Limit "<%= node['apt']['unattended_upgrades']['dl_limit'] %>";
 Unattended-Upgrade::SyslogEnable "<%= node['apt']['unattended_upgrades']['syslog_enable'] ? 'true' : 'false' %>";
 
 // Specify syslog facility. Default is daemon
-Unattended-Upgrade::SyslogFacility "<%= node['apt']['unattended_upgrades']['syslog_facility']";
+Unattended-Upgrade::SyslogFacility "<%= node['apt']['unattended_upgrades']['syslog_facility'] %>";


### PR DESCRIPTION
### Description

* Added support for the unattended-upgrade SyslogEnable configuration feature
* Added support for the unattended-upgrade SyslogFacility configuration feature

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
