### PR TITLE
Allow to customize sender email for unattended-upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ To pull just security updates, set `origins_patterns` to something like `["origi
 - `['apt']['unattended_upgrades']['minimal_steps']` - Split the upgrade into the smallest possible chunks. This makes the upgrade a bit slower but it has the benefit that shutdown while a upgrade is running is possible (with a small delay). Defaults to false.
 - `['apt']['unattended_upgrades']['install_on_shutdown']` - Install upgrades when the machine is shuting down instead of doing it in the background while the machine is running. This will (obviously) make shutdown slower. Defaults to false.
 - `['apt']['unattended_upgrades']['mail']` - Send email to this address for problems or packages upgrades. Defaults to no email.
+- `['apt']['unattended_upgrades']['sender']` - Send email from this address for problems or packages upgrades. Defaults to 'root'.
 - `['apt']['unattended_upgrades']['mail_only_on_error']` - If set, email will only be set on upgrade errors. Otherwise, an email will be sent after each upgrade. Defaults to true.
 - `['apt']['unattended_upgrades']['remove_unused_dependencies']` Do automatic removal of new unused dependencies after the upgrade. Defaults to false.
 - `['apt']['unattended_upgrades']['automatic_reboot']` - Automatically reboots _without confirmation_ if a restart is required after the upgrade. Defaults to false.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,6 +41,7 @@ default['apt']['unattended_upgrades']['auto_fix_interrupted_dpkg'] = false
 default['apt']['unattended_upgrades']['minimal_steps'] = false
 default['apt']['unattended_upgrades']['install_on_shutdown'] = false
 default['apt']['unattended_upgrades']['mail'] = nil
+default['apt']['unattended_upgrades']['sender'] = nil
 default['apt']['unattended_upgrades']['mail_only_on_error'] = true
 default['apt']['unattended_upgrades']['remove_unused_dependencies'] = false
 default['apt']['unattended_upgrades']['automatic_reboot'] = false

--- a/templates/50unattended-upgrades.erb
+++ b/templates/50unattended-upgrades.erb
@@ -25,7 +25,7 @@ Unattended-Upgrade::Package-Blacklist {
 };
 
 // This option allows you to control if on a unclean dpkg exit
-// unattended-upgrades will automatically run 
+// unattended-upgrades will automatically run
 //   dpkg --force-confold --configure -a
 // The default is true, to ensure updates keep getting installed
 Unattended-Upgrade::AutoFixInterruptedDpkg "<%= node['apt']['unattended_upgrades']['auto_fix_interrupted_dpkg'] ? 'true' : 'false' %>";
@@ -41,12 +41,18 @@ Unattended-Upgrade::MinimalSteps "<%= node['apt']['unattended_upgrades']['minima
 // This will (obviously) make shutdown slower
 Unattended-Upgrade::InstallOnShutdown "<%= node['apt']['unattended_upgrades']['install_on_shutdown'] ? 'true' : 'false' %>";
 
+<% if node['apt']['unattended_upgrades']['mail'] -%>
 // Send email to this address for problems or packages upgrades
 // If empty or unset then no email is sent, make sure that you
 // have a working mail setup on your system. A package that provides
 // 'mailx' must be installed.
-<% if node['apt']['unattended_upgrades']['mail'] -%>
 Unattended-Upgrade::Mail "<%= node['apt']['unattended_upgrades']['mail'] %>";
+<% end -%>
+
+<% if node['apt']['unattended_upgrades']['sender'] -%>
+// This option allows to customize the email address used in the
+// 'From' header. unattended-upgrades will use "root" if unset.
+Unattended-Upgrade::Sender "<%= node['apt']['unattended_upgrades']['sender'] %>";
 <% end -%>
 
 // Set this value to "true" to get emails only on errors. Default
@@ -57,20 +63,20 @@ Unattended-Upgrade::MailOnlyOnError "<%= node['apt']['unattended_upgrades']['mai
 // (equivalent to apt-get autoremove)
 Unattended-Upgrade::Remove-Unused-Dependencies "<%= node['apt']['unattended_upgrades']['remove_unused_dependencies'] ? 'true' : 'false' %>";
 
-// Automatically reboot *WITHOUT CONFIRMATION* if a 
-// the file /var/run/reboot-required is found after the upgrade 
+// Automatically reboot *WITHOUT CONFIRMATION* if a
+// the file /var/run/reboot-required is found after the upgrade
 Unattended-Upgrade::Automatic-Reboot "<%= node['apt']['unattended_upgrades']['automatic_reboot'] ? 'true' : 'false' %>";
 
-// If automatic reboot is enabled and needed, reboot at the specific
-// time instead of immediately
-//  Default: "now"
 <% if node['apt']['unattended_upgrades']['automatic_reboot'] -%>
+// If automatic reboot is enabled and needed, reboot at the specific
+// time instead of immediately. Default is "now"
 Unattended-Upgrade::Automatic-Reboot-Time "<%= node['apt']['unattended_upgrades']['automatic_reboot_time'] %>";
 <% end %>
 
+<% if node['apt']['unattended_upgrades']['dl_limit'] -%>
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec
-<% if node['apt']['unattended_upgrades']['dl_limit'] -%>
+// Acquire::http::Dl-Limit "70";
 Acquire::http::Dl-Limit "<%= node['apt']['unattended_upgrades']['dl_limit'] %>";
 <% end -%>
 


### PR DESCRIPTION
### Description

This allows to customize the sender address used in emails sent by `unattended-upgrades`.

### Issues Resolved

Override the default `root` sender:

```bash
$ grep "Unattended-Upgrade::Sender" /usr/bin/unattended-upgrade
    from_email = apt_pkg.config.find("Unattended-Upgrade::Sender", "root")
```

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>

Not applicable (see below).

- [x] New functionality includes testing.

The tests for unattended-upgrades are currently commented out in `spec/unit/recipes/unattended-upgrades_spec.rb`. This change is fairly straightforward as it's very similar to the existing `node['apt']['unattended_upgrades']['mail']` attribute.

- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>