### PR TITLE
allow you to specify dpkg options just for unattended upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ For example, to prevent caching and directly connect to the repository at `downl
             "cacher_server": {
                 "cache_bypass": {
                     "download.oracle.com": "http",
-                    "nginx.org": "https"  
+                    "nginx.org": "https"
                 }
             }
         }
@@ -137,6 +137,7 @@ To pull just security updates, set `origins_patterns` to something like `["origi
 - `['apt']['unattended_upgrades']['random_sleep']` - Wait a random number of seconds up to this value before running daily periodic apt actions. System default is 1800 seconds (30 minutes).
 - `['apt']['unattended_upgrades']['syslog_enable']` - Enable logging to syslog. Defaults to false.
 - `['apt']['unattended_upgrades']['syslog_facility']` - Specify syslog facility. Defaults to 'daemon'.
+- `['apt']['unattended_upgrades']['dpkg_options']` An array of dpkg options to be used specifically only for unattended upgrades. Defaults to `[]` which will prevent it from being rendered from the template in the resulting file.
 
 ### Configuration for APT
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,6 +51,8 @@ default['apt']['unattended_upgrades']['random_sleep'] = nil
 default['apt']['unattended_upgrades']['syslog_enable'] = false
 default['apt']['unattended_upgrades']['syslog_facility'] = 'daemon'
 
+default['apt']['unattended_upgrades']['dpkg_options'] = []
+
 default['apt']['confd']['force_confask'] = false
 default['apt']['confd']['force_confdef'] = false
 default['apt']['confd']['force_confmiss'] = false

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -41,7 +41,15 @@ suites:
   - name: resources
     run_list:
       - recipe[test::resources]
+      # test that you can specifically modify some unattended upgrades options but leave the majority in place
+      - recipe[test::unattended-upgrades]
     excludes: centos-7
+    attributes:
+      apt:
+        unattended_upgrades:
+          dpkg_options:
+            - --force-confdef
+            - --force-confold
 
   - name: unattended-upgrades
     run_list:

--- a/templates/50unattended-upgrades.erb
+++ b/templates/50unattended-upgrades.erb
@@ -85,3 +85,20 @@ Unattended-Upgrade::SyslogEnable "<%= node['apt']['unattended_upgrades']['syslog
 
 // Specify syslog facility. Default is daemon
 Unattended-Upgrade::SyslogFacility "<%= node['apt']['unattended_upgrades']['syslog_facility'] %>";
+
+// specify any dpkg options you want to run
+// for example if you wanted to upgrade and use
+// the installed version of config files when
+// resolving conflicts during an upgrade you
+// typically need:
+// Dpkg::Options {
+//   "--force-confdef";
+//   "--force-confold";
+//};
+<% unless node['apt']['unattended_upgrades']['dpkg_options'].empty? -%>
+Dpkg::Options {
+<% node['apt']['unattended_upgrades']['dpkg_options'].each do |option|%>
+	"<%= option %>";
+<% end -%>
+};
+<% end -%>

--- a/test/integration/resources/unattended_upgrades_spec.rb
+++ b/test/integration/resources/unattended_upgrades_spec.rb
@@ -1,0 +1,10 @@
+if os.name == 'debian' || os.name == 'ubuntu'
+
+  describe file('/etc/apt/apt.conf.d/50unattended-upgrades') do
+    it { should be_file }
+    it { should be_owned_by 'root' }
+    it { should be_grouped_into 'root' }
+    it { should be_mode 0644 }
+    its(:content) { should match(/"--force-confold";/) }
+  end
+end


### PR DESCRIPTION
This differs from existing functionality that allows it to be set globally.

Signed-off-by: Ben Abrams <me@benabrams.it>

### Description

Allows passing of dpkg options specifically for unattended upgrades


### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
