### PR TITLE
Prevent helper collisions in Chef Infra Client 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,13 @@ env:
   - INSTANCE=default-debian-10
   - INSTANCE=default-ubuntu-1604
   - INSTANCE=default-ubuntu-1804
+  - INSTANCE=default-ubuntu-2004
   - INSTANCE=cacher-debian-9
   - INSTANCE=cacher-debian-10
   - INSTANCE=cacher-ubuntu-1604
   - INSTANCE=compile-time-ubuntu-1604
   - INSTANCE=compile-time-ubuntu-1804
+  - INSTANCE=compile-time-ubuntu-2004
   - INSTANCE=compile-time-debian-9
   - INSTANCE=compile-time-debian-10
   - INSTANCE=unattended-upgrades-ubuntu-1604

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,3 @@ before_script:
   - chef --version
 
 script: KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen verify ${INSTANCE}
-
-matrix:
-  include:
-    - script:
-      - delivery local all
-      env:
-        - UNIT_AND_LINT=1
-        - CHEF_LICENSE=accept

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -49,3 +49,8 @@ platforms:
   driver:
     image: dokken/ubuntu-18.04
     pid_one_command: /bin/systemd
+
+- name: ubuntu-20.04
+  driver:
+    image: dokken/ubuntu-20.04
+    pid_one_command: /bin/systemd

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -24,13 +24,13 @@ module Apt
     #
     # @return [Boolean]
     def apt_installed?
-      !which('apt-get').nil?
+      !apt_which('apt-get').nil?
     end
 
     # Finds a command in $PATH
     #
     # @return [String, nil]
-    def which(cmd)
+    def apt_which(cmd)
       ENV['PATH'] = '' if ENV['PATH'].nil?
       paths = (ENV['PATH'].split(::File::PATH_SEPARATOR) + %w(/bin /usr/bin /sbin /usr/sbin))
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,7 +43,6 @@ end
 
 # For other recipes to call to force an update
 execute 'apt-get update' do # rubocop: disable ChefModernize/ExecuteAptUpdate
-  command 'apt-get update'
   ignore_failure true
   action :nothing
   notifies :touch, 'file[/var/lib/apt/periodic/update-success-stamp]', :immediately


### PR DESCRIPTION
which is a built-in helper in Chef Infra Client 16 and the helper here
is defining that name again and breaking resources within the client.

Signed-off-by: Tim Smith <tsmith@chef.io>